### PR TITLE
New attribute to media.Track() class: 'full_name'

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -129,6 +129,7 @@ class Track(Media):
     isrc = None
     audio_quality = None
     version = None
+    full_name = None
     copyright = None
 
     def parse_track(self, json_obj):
@@ -141,6 +142,11 @@ class Track(Media):
             self.copyright = json_obj['copyright']
         self.audio_quality = tidalapi.Quality(json_obj['audioQuality'])
         self.version = json_obj['version']
+
+        if self.version is not None:
+            self.full_name = (f"{json_obj['title']} ({json_obj['version']})")
+        else:
+            self.full_name = json_obj['title']
 
         return copy.copy(self)
 


### PR DESCRIPTION
The objects of the tidalapi.media.Tracks() class have a new attribute: full_name.
It contains the title / name of the song + the 'version'. The version is used to add information on what version of the track this is; when it's a remixed version of the song it contains the name of the remix artist, if it's the radio version or the extended version etc this is usually the place where that information is saved.

However, the use of that attribute is inconsistent: Some tracks use it, others put that information directly in to the title / name of the track. The 'full_name' attribute provides that consistency by adding 'name' and 'version' together when the 'version' attribute is used.